### PR TITLE
[coef.py] fix bug in localizeCoefficient

### DIFF
--- a/gridlod/coef.py
+++ b/gridlod/coef.py
@@ -12,7 +12,8 @@ def localizeCoefficient(patch, aFine):
     
     # a
     coarsetIndexMap = util.lowerLeftpIndexMap(NPatchFine-1, NWorldFine-1)
-    coarsetStartIndex = util.convertpCoordIndexToLinearIndex(NPatchFine-1, iPatchWorldFine)
+    coarsetStartIndex = util.convertpCoordIndexToLinearIndex(NWorldFine-1, iPatchWorldFine)
     aFineLocalized = aFine[coarsetStartIndex + coarsetIndexMap]
-    
     return aFineLocalized
+
+


### PR DESCRIPTION
This bug is very simple but took me hours to find. 

I noticed this by observing that the ErrorIndicator did not locate the defect where it really was. Instead there were high values in regions where there is no defect at all. 

Almost driving me completely mad. But at least I found it. 