### PR TITLE
[lod] first draft of matrix coarse error indiactor

### DIFF
--- a/gridlod/test/test_lod.py
+++ b/gridlod/test/test_lod.py
@@ -362,7 +362,13 @@ class errorIndicators_TestCase(unittest.TestCase):
         # Expect: 0 error indicator
         aOld = np.ones(world.NtFine, dtype=np.float64)
         aNew = aOld
-        
+
+        self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew), 0)
+
+        #### Same test for Matrix valued ####
+        Aeye = np.tile(np.eye(2), [np.prod(NFine), 1, 1])
+        aNew = np.einsum('tji, t -> tji', Aeye, aNew)
+
         self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew), 0)
 
         ## Case
@@ -371,7 +377,14 @@ class errorIndicators_TestCase(unittest.TestCase):
         # Expect: sqrt(1/10 * 1/10*(10-1)**2*1 * (NtCoarse)*(NtCoarse+1)/2)
         aOld = np.ones(world.NtFine, dtype=np.float64)
         aNew = 10*aOld
-        
+
+        self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew),
+                               np.sqrt(1/10 * 1/10*(10-1)**2*1 * (NtCoarse)*(NtCoarse+1)/2))
+
+        #### Same test for Matrix valued ####
+        aNew = np.einsum('tji, t -> tji', Aeye, aNew)
+        aOld = np.einsum('tji, t-> tji', Aeye, aOld)
+
         self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew),
                                np.sqrt(1/10 * 1/10*(10-1)**2*1 * (NtCoarse)*(NtCoarse+1)/2))
         
@@ -387,9 +400,15 @@ class errorIndicators_TestCase(unittest.TestCase):
                                                        np.array([2, 0]),
                                                        extractElements=True)
         aNew[elementFinetIndexMap] = 10
-        
+
         self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew),
                                np.sqrt(1 * 1/10*(10-1)**2*1 * 3))
-    
+
+        #### Same test for Matrix valued ####
+        aOld = np.einsum('tji, t-> tji', Aeye, aOld)
+
+        self.assertAlmostEqual(lod.computeErrorIndicatorCoarseFromCoefficients(patch, muTPrime, aOld, aNew),
+                               np.sqrt(1 * 1/10*(10-1)**2*1 * 3))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a first draft of computeErrorIndicatorCoarseFromCoefficients for the matrix valued case. 
I use scipy.linalg.sqrtm which computes the principal square root of the matrix. 

However, there is an issue: The tests say that the result is equal to the result before (see test_lod.py). A test in gridlod-on-perturbations shows me that this coarse indicator is not always larger than the fine error indicator (which should be the case according to our error analysis). 

I found out that coarse indicator is always larger then fine indicator if I do not compute max norm but the Frobenius norm in the deltaTprime. However, then the result does not fit to the result from the non matrix valued case and the test_lod.py fails. 

Any ideas what we want to do? Maybe we turn to Frobenius norm? 
To be completely honest, it does not really matter for our purposes since we do not rely on the coarse indicator being larger then the fine one. It is only important that the behavior is the same. This is true for both norms. 